### PR TITLE
Fix dimension sorting bug in Box constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -404,7 +404,15 @@ class Box {
         // prices: [np_float, sp_float, fp_float, cp_float] -> price for each packing level OR itemized-prices object
         const open_dim_val = dimensions[open_dim]
         this.dimensions = dimensions.toSorted((a, b) => b - a)     // Just to presort by size
-        this.open_dim = this.dimensions.findIndex((e) => {return e == open_dim_val})
+        // Find where the open dimension ended up after sorting
+        this.open_dim = this.dimensions.indexOf(open_dim_val);
+        // Handle case where multiple dimensions have the same value
+        if (this.open_dim === -1 || dimensions.filter(d => d === open_dim_val).length > 1) {
+            // If dimensions are not unique, we need to track more carefully
+            const dimWithIndex = dimensions.map((d, i) => ({value: d, originalIndex: i}));
+            dimWithIndex.sort((a, b) => b.value - a.value);
+            this.open_dim = dimWithIndex.findIndex(d => d.originalIndex === open_dim);
+        }
         
         // Handle both standard and itemized pricing
         if (Array.isArray(prices)) {


### PR DESCRIPTION
The Box class was incorrectly tracking the open dimension after sorting. When dimensions were sorted from largest to smallest, the code used findIndex with loose equality (==) which could return incorrect results, especially when:
- The open dimension was the largest (would be at index 0 after sorting, not 2)
- Multiple dimensions had the same value

This fix:
1. Uses indexOf for the initial search (strict equality)
2. Handles duplicate dimensions by tracking original indices
3. Ensures the correct dimension is identified as 'open' after sorting

This bug affected telescoping calculations, cut-down calculations, and constraint calculations for non-cubic boxes where the depth wasn't the smallest dimension.